### PR TITLE
feat: adapt the keeper methods to gelato infra

### DIFF
--- a/src/aura/AuraConstants.sol
+++ b/src/aura/AuraConstants.sol
@@ -13,6 +13,7 @@ import {IVault} from "../interfaces/badger/IVault.sol";
 import {IBalancerVault} from "../interfaces/balancer/IBalancerVault.sol";
 import {IPriceOracle} from "../interfaces/balancer/IPriceOracle.sol";
 import {IAggregatorV3} from "../interfaces/chainlink/IAggregatorV3.sol";
+import {IGelatoOps} from "../interfaces/gelato/IGelatoOps.sol";
 
 abstract contract AuraConstants {
     IBalancerVault internal constant BALANCER_VAULT = IBalancerVault(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
@@ -54,4 +55,6 @@ abstract contract AuraConstants {
 
     uint256 internal constant BAL_USD_FEED_DIVISOR = 1e20;
     uint256 internal constant AURA_USD_FEED_DIVISOR = 1e38;
+
+    IGelatoOps internal constant GELATO_OPS = IGelatoOps(0xB3f5503f93d5Ef84b06993a1975B9D21B962892F);
 }

--- a/src/interfaces/gelato/IGelatoOps.sol
+++ b/src/interfaces/gelato/IGelatoOps.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IGelatoOps {
+    function createTask(
+        address _execAddress,
+        bytes4 _execSelector,
+        address _resolverAddress,
+        bytes calldata _resolverData
+    ) external returns (bytes32 task);
+
+    function cancelTask(bytes32 _taskId) external;
+}


### PR DESCRIPTION
- Adds method to create the task in the ops gelato contract within the avatar, also to kill it permissioned only to owner

- Renaming a bit the methods which keeper has permission on

- Adds necessary gelato interfaces

